### PR TITLE
change sonar project name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         
         <sonar.organization>fhhagenberg-sqe</sonar.organization>
         <sonar.projectKey>project-sqelevator-mcm-team-1-1</sonar.projectKey>
+		<sonar.projectName>ElevatorCC - Team 1</sonar.projectName>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 


### PR DESCRIPTION
I've changed the sonar project name to avoid ambiguities on SonarCloud.
Btw.: Before analysis is done automatically on every push or pull request, analysis has to be started manally once! This can be done via:
`mvn -B clean verify sonar:sonar -Dsonar.login=039645d...<rest-of-secret-key>`.

(I've already done this for you, so automatic analysis should work from now on...)